### PR TITLE
Update border color for welcome panel in dashboard CSS

### DIFF
--- a/src/wp-admin/css/dashboard.css
+++ b/src/wp-admin/css/dashboard.css
@@ -140,8 +140,7 @@
 	position: relative;
 	overflow: auto;
 	margin: 16px 0;
-	background-color: #c3c4c7;
-	border: 1px solid rgb(0, 0, 0, 0.1);
+	border: 1px solid #c3c4c7;
 	border-radius: 8px;
 	font-size: 14px;
 	line-height: 1.3;


### PR DESCRIPTION
If we add `background-color: #151515` to `welcome-panel-content` to fix this: https://github.com/WordPress/wordpress-develop/pull/11105, it might be better to remove the background from `welcome-panel` and simply modify the border color instead. Does that make sense?

Trac ticket: https://core.trac.wordpress.org/ticket/64741